### PR TITLE
Custom mollifier

### DIFF
--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -1745,7 +1745,7 @@ def khf_2d(kmf, nks, uKpts, ex, N_local=5, debug=False, localizer=default_locali
 
     #   localizer for the local domain
     r1 = np.min(LsCell_bz_local_norms[0:2]) / 2
-    H = lambda q: poly_localizer(q, r1, d=localizer_degree)
+    H = lambda q: localizer(q,r1)
 
     #   reciprocal lattice within the local domain
     #   Needs modification for 2D

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -1624,7 +1624,10 @@ def khf_exchange_ss(kmf, nks, uKpts, made, N_local=5):
 
     return e_ex_ss, e_ex_ss2
 
-def khf_2d(kmf, nks, uKpts, ex, N_local = 5,localizer_degree=4,debug = False):
+
+import ss_localizers
+default_localizer = lambda q,r1:ss_localizers.localizer_poly_2d(q,r1,4)
+def khf_2d(kmf, nks, uKpts, ex, N_local=5, debug=False, localizer=default_localizer):
     from scipy.special import sici
     from scipy.special import iv
     def minimum_image(cell, kpts):
@@ -1643,17 +1646,6 @@ def khf_2d(kmf, nks, uKpts, ex, N_local = 5,localizer_degree=4,debug = False):
         tmp_kpt[tmp_kpt > 0.5 - 1e-8] -= 1
         kpts_bz = cell.get_abs_kpts(tmp_kpt)
         return kpts_bz
-
-    def poly_localizer(x, r1, d):
-        x = np.asarray(x)
-        x = x[:, :2] / r1
-        r = np.linalg.norm(x, axis=1) if x.ndim > 1 else np.linalg.norm(x)
-        val = (1 - r ** d) ** d
-        if x.ndim > 1:
-            val[r > 1] = 0
-        elif r > 1:
-            val = 0
-        return val
 
     #   basic info
     cell = kmf.cell
@@ -1743,7 +1735,7 @@ def khf_2d(kmf, nks, uKpts, ex, N_local = 5,localizer_degree=4,debug = False):
 
     #   localizer for the local domain
     r1 = np.min(LsCell_bz_local_norms[0:2]) / 2
-    H = lambda q: poly_localizer(q, r1, d=localizer_degree)
+    H = lambda q: localizer(q,r1)
 
     #   reciprocal lattice within the local domain
     #   Needs modification for 2D

--- a/pyscf/pbc/scf/ss_localizers.py
+++ b/pyscf/pbc/scf/ss_localizers.py
@@ -1,0 +1,43 @@
+import numpy as np
+def localizer_poly_2d(x, r1, d):
+    x = np.asarray(x)
+    x = x[:, :2] / r1
+    r = np.linalg.norm(x, axis=1) if x.ndim > 1 else np.linalg.norm(x)
+    val = (1 - r ** d) ** d
+    if x.ndim > 1:
+        val[r > 1] = 0
+    elif r > 1:
+        val = 0
+    return val
+def localizer_exp_2d(x, r1, d):
+    c = 1.0
+    x = np.asarray(x)
+    x = x[:, :2] / r1
+    r = np.linalg.norm(x, axis=1) if x.ndim > 1 else np.linalg.norm(x)
+    val = np.exp(-c/(1.-np.power(r,d))) / np.exp(c)
+    if x.ndim > 1:
+        val[r > 1] = 0
+    elif r > 1:
+        val = 0
+    return val
+
+def localizer_int_exp_2d(x, r1, d):
+    x = np.asarray(x)
+    x = x[:, :2] / r1
+    r = np.linalg.norm(x, axis=1) if x.ndim > 1 else np.linalg.norm(x)
+
+    c = 1.0
+    g = lambda x: np.exp(-c/(1-x**d))
+
+    from scipy.integrate import quad
+    int_g = quad(g,-1,1)
+    h = lambda x: quad(g,-1,x) / int_g
+    f = lambda y: h(1-2*np.abs(1))
+
+    val = f(r)
+
+    if x.ndim > 1:
+        val[r > 1] = 0
+    elif r > 1:
+        val = 0
+    return val

--- a/pyscf/pbc/scf/subsample_kpts.py
+++ b/pyscf/pbc/scf/subsample_kpts.py
@@ -99,7 +99,7 @@ def subsample_kpts(mf, dim, div_vector, dm_kpts = None, stagger_type = None, df_
             mf.exxdiv = None #so that standard energy is computed without madelung
             E_standard, E_madelung, uKpts = make_ss_inputs(kmf=mf, kpts=kpts_div, dm_kpts=dm_kpts,
                                                            mo_coeff_kpts=mo_coeff_kpts)
-            e_ss = khf_2d(mf, nks, uKpts, E_standard, N_local=ss_nlocal,localizer_degree=4,debug=True)
+            e_ss = khf_2d(mf, nks, uKpts, E_standard, N_local=ss_nlocal, debug=True)
             print('Ek (Madelung) (a.u.) = ', E_madelung, file=f)
             print('Ek (SS) (a.u.) = ', e_ss, file=f)
 

--- a/pyscf/pbc/scf/subsample_kpts.py
+++ b/pyscf/pbc/scf/subsample_kpts.py
@@ -53,11 +53,14 @@ def subsample_kpts(mf, dim, div_vector, dm_kpts = None, stagger_type = None, df_
     print('Ej (a.u.) = ', Ej, file=f)
     print('Ek (a.u.) = ', Ek, file=f)
 
-    Ek_list = []
-    Ej_list = []
-
-    nk_list = []
-    nks_list = []
+    results = {
+        "Ek_list":[],
+        "Ej_list":[],
+        "nk_list":[],
+        "nks_list":[],
+        "Ek_stagger_list":[],
+        "Ek_ss_list":[]
+    }
 
     if stagger_type is not None:
         print('Warning, no J term computed', file=f)
@@ -103,18 +106,20 @@ def subsample_kpts(mf, dim, div_vector, dm_kpts = None, stagger_type = None, df_
             print('Ek (Madelung) (a.u.) = ', E_madelung, file=f)
             print('Ek (SS) (a.u.) = ', e_ss, file=f)
 
-            Ek_list.append(e_ss)
-            nk_list.append(nk_div)
-            nks_list.append(copy.copy(nks))
+            results["Ek_ss_list"].append(e_ss)
+            results["Ek_list"].append(E_madelung)
+            results["nk_list"].append(nk_div)
+            results["nks_list"].append(copy.copy(nks))
         elif stagger_type !=None:
             from pyscf.pbc.scf.khf import khf_stagger
 
             Ek_stagger_M, Ek_stagger, Ek_standard = khf_stagger(icell=mf.cell, ikpts=kpts_div, version=stagger_type, df_type=df_type, dm_kpts=dm_kpts)
 
             print('Ek (a.u.) = ', Ek_stagger_M, file=f)
-            Ek_list.append(Ek_stagger_M)
-            nk_list.append(nk_div)
-            nks_list.append(copy.copy(nks))
+            results["Ek_stagger_list"].append(Ek_stagger_M)
+            results["Ek_list"].append(Ek_standard)
+            results["nk_list"].append(nk_div)
+            results["nks_list"].append(copy.copy(nks))
 
         else:
 
@@ -131,16 +136,16 @@ def subsample_kpts(mf, dim, div_vector, dm_kpts = None, stagger_type = None, df_
 
             print('Ej (a.u.) = ', Ej, file = f)
             print('Ek (a.u.) = ', Ek, file = f)
-            Ej_list.append(Ej)
-            Ek_list.append(Ek)
-            nk_list.append(nk_div)
-            nks_list.append(copy.copy(nks))
+            results["Ej_list"].append(Ej)
+            results["Ek_list"].append(Ek)
+            results["nk_list"].append(nk_div)
+            results["nks_list"].append(copy.copy(nks))
 
         kpts_div_old = kpts_div
 
 
 
-    return nk_list, nks_list, Ej_list, Ek_list
+    return results
 
 
 

--- a/pyscf/pbc/scf/test/BN_ss_22.py
+++ b/pyscf/pbc/scf/test/BN_ss_22.py
@@ -42,7 +42,7 @@ filename = 'BN_HF_' + str(nks[0]) + str(nks[1])  +'.pkl'
 with open(filename,'rb') as file:
      data = pickle.load(file)
 
-e_ss = khf_2d(kmf, nks,data["uKpts"],data["e_ex_m"], N_local = 9,debug=True)
+e_ss = khf_2d(kmf, nks, data["uKpts"], data["e_ex_m"], N_local=9, debug=True)
 
 print("Regular energy")
 print(data["e_ex_m"])

--- a/pyscf/pbc/scf/test/H2_ss_22.py
+++ b/pyscf/pbc/scf/test/H2_ss_22.py
@@ -41,7 +41,7 @@ import pickle
 with open('H2_HF_22_vac24.pkl','rb') as file:
      data = pickle.load(file)
 
-e_ss = khf_2d(kmf, nks,data["uKpts"],data["e_ex_m"], N_local = 9,debug=True,localizer_degree=4)
+e_ss = khf_2d(kmf, nks, data["uKpts"], data["e_ex_m"], N_local=9, debug=True)
 
 print("Regular energy")
 print(data["e_ex_m"])

--- a/pyscf/pbc/scf/test/benchmark_khf_ss_subsampling.py
+++ b/pyscf/pbc/scf/test/benchmark_khf_ss_subsampling.py
@@ -158,13 +158,13 @@ print('Ecoul (a.u.) is ', Ek + Ej)
 
 
 div_vector = [2,2]
-nk_list, nks_list, Ej_list, Ek_list = subsample_kpts(mf=mf,dim=2,div_vector=div_vector, df_type=df_type, singularity_subtraction=True,wrap_around=wrap_around)
+results = subsample_kpts(mf=mf,dim=2,div_vector=div_vector, df_type=df_type, singularity_subtraction=True,wrap_around=wrap_around)
 
 
 print('=== Kpoint Subsampling Results (SS) === ')
 print('\nnk list')
-print(nk_list)
+print(results["nk_list"])
 print('\nnks list')
-print(nks_list)
+print(results["nks_list"])
 print('\nEk list')
-print(Ek_list)
+print(results["Ek_list"])


### PR DESCRIPTION
Add capability to feed user-defined mollifiers to khf_2d. See `khf_2d` for usage and the default localizers in  `pyscf.pbc.scf.ss_localizers`. Recommend that one feeds a lambda function of a localizer function that takes in `q` and `r1` exactly. 

Also changed the return signature of `subsample_kpts`.